### PR TITLE
Fixes for querystring encode/decode

### DIFF
--- a/test/querystring_test.py
+++ b/test/querystring_test.py
@@ -95,7 +95,7 @@ class QueryStringTest(unittest.TestCase):
 
     def test_add_param_encodes_special_characters(self):
         s = QueryString(u'abc=123')
-        assert s.add_param(u'd e f', u'4+5#6') == u'abc=123&d%20e%20f=4%2B5%236'
+        assert s.add_param(u'd e f', u'4+5#6') == u'abc=123&d+e+f=4%2B5%236'
 
     def test_set_param_replaces_existing_parameter_names(self):
         s = QueryString(u'abc=123&abc=456')

--- a/urlobject/query_string.py
+++ b/urlobject/query_string.py
@@ -92,8 +92,18 @@ class QueryString(unicode):
         return qs
 
 
-qs_encode = lambda s: urllib.quote(s.encode('utf-8'))
-qs_decode = lambda s: urllib.unquote(str(s).replace('+', ' ')).decode('utf-8')
+def qs_encode(s):
+    """Quote unicode or str using query string rules."""
+    if isinstance(s, unicode):
+        s = s.encode('utf-8')
+    return urllib.quote_plus(s).decode('utf-8')
+
+
+def qs_decode(s):
+    """Unquote unicode or str using query string rules."""
+    if isinstance(s, unicode):
+        s = s.encode('utf-8')
+    return urllib.unquote_plus(s).decode('utf-8')
 
 
 def get_params_list(*args, **kwargs):


### PR DESCRIPTION
This commit brings three fixes to qs_encode and qs_decode:
1. Use quote_plus/unquote_plus rather than quote/unquote so that spaces are encoded as +.
2. Avoid implicit s.decode in qs_encode. This happens if a str is passed to qs_encode, since s.encode in that case needs to decode first.
3. Avoid implicit s.encode in qs_decode. This happens because of calling str(s).

The implicit conversions use the (platform and environment dependant) default encoding, so it's better to avoid them and explicitly handle unicode objects with deliberate encode/decode to utf-8.
