### PR TITLE
Browser-like unicode URL support

### DIFF
--- a/test/urlobject_test.py
+++ b/test/urlobject_test.py
@@ -333,20 +333,20 @@ class URLObjectModificationTest(unittest.TestCase):
                 'https://github.com/zacharyvoase/urlobject?spam=eggs')
 
 
-class URLObjectEncodeTest(unittest.TestCase):
+class URLObjectReencodeTest(unittest.TestCase):
 
     def test_encode_hostname_idna(self):
-        assert (URLObject(u('https://host-\u03bb.com/')).encode() ==
+        assert (URLObject(u('https://host-\u03bb.com/')).reencode() ==
                 'https://xn--host--6be.com/')
 
     def test_encode_path(self):
-        assert (URLObject(u('https://example.com/path-\u03bb/path2')).encode() ==
+        assert (URLObject(u('https://example.com/path-\u03bb/path2')).reencode() ==
                 'https://example.com/path-%CE%BB/path2')
 
     def test_encode_query(self):
-        assert (URLObject(u('https://example.com/?key-\u03bb=val-\u03bb')).encode() ==
+        assert (URLObject(u('https://example.com/?key-\u03bb=val-\u03bb')).reencode() ==
                 'https://example.com/?key-%CE%BB=val-%CE%BB')
 
     def test_encode_fragment(self):
-        assert (URLObject(u('https://example.com/#fr\u03bbgment')).encode() ==
+        assert (URLObject(u('https://example.com/#fr\u03bbgment')).reencode() ==
                 'https://example.com/#fr%CE%BBgment')

--- a/urlobject/urlobject.py
+++ b/urlobject/urlobject.py
@@ -538,7 +538,7 @@ class URLObject(text_type):
         return type(self)(urlparse.urlunsplit(
             urlparse.urlsplit(self)._replace(**replace)))
 
-    def encode(self):
+    def reencode(self):
         """
         Return an ASCII, URL-quoted, UTF-8-encoded, IDNA-conformant
         representation of the URL.
@@ -547,7 +547,7 @@ class URLObject(text_type):
         the first place, and so is useful for re-encoding a URL that was
         entered by a user.
 
-        >>> print(URLObject(u("http://éxample.com:80/påth/sëgment/?que®y=vałue#frågment")).encode())
+        >>> print(URLObject(u("http://éxample.com:80/påth/sëgment/?que®y=vałue#frågment")).reencode())
         http://xn--xample-9ua.com:80/p%C3%A5th/s%C3%ABgment/?que%C2%AEy=va%C5%82ue#fr%C3%A5gment
         """
         query = path_encode(self.query, safe='?&=')


### PR DESCRIPTION
This addresses both #22 and #23.
- with_netloc now encodes the netloc with IDNA
- a new 'encode' method re-encodes the entire URL so it's properly escaped
