### PR TITLE
Change Python version checking due conflicts with libraries that patch urllib patching 

### DIFF
--- a/urlobject/query_string.py
+++ b/urlobject/query_string.py
@@ -150,13 +150,13 @@ def _qs_decode_py3(s):
     return urlparse.unquote_plus(s)
 
 
-if PY2:
-    qs_encode = _qs_encode_py2
-    qs_decode = _qs_decode_py2
-    del _qs_encode_py3
-    del _qs_decode_py3
-else:
+if PY3:
     qs_encode = _qs_encode_py3
     qs_decode = _qs_decode_py3
     del _qs_encode_py2
     del _qs_decode_py2
+else:
+    qs_encode = _qs_encode_py2
+    qs_decode = _qs_decode_py2
+    del _qs_encode_py3
+    del _qs_decode_py3

--- a/urlobject/query_string.py
+++ b/urlobject/query_string.py
@@ -1,13 +1,9 @@
 import collections
 import re
-import sys
 import urllib
 
 from .compat import urlparse
-from .six import text_type, string_types, u
-
-
-PY2 = sys.version_info[0] == 2
+from .six import PY2, text_type, string_types, u
 
 
 class QueryString(text_type):

--- a/urlobject/query_string.py
+++ b/urlobject/query_string.py
@@ -7,7 +7,6 @@ from .compat import urlparse
 from .six import text_type, string_types, u
 
 
-PY3 = sys.version_info[0] == 3
 PY2 = sys.version_info[0] == 2
 
 
@@ -150,13 +149,13 @@ def _qs_decode_py3(s):
     return urlparse.unquote_plus(s)
 
 
-if PY3:
-    qs_encode = _qs_encode_py3
-    qs_decode = _qs_decode_py3
-    del _qs_encode_py2
-    del _qs_decode_py2
-else:
+if PY2:
     qs_encode = _qs_encode_py2
     qs_decode = _qs_decode_py2
     del _qs_encode_py3
     del _qs_decode_py3
+else:
+    qs_encode = _qs_encode_py3
+    qs_decode = _qs_decode_py3
+    del _qs_encode_py2
+    del _qs_decode_py2

--- a/urlobject/query_string.py
+++ b/urlobject/query_string.py
@@ -1,9 +1,14 @@
 import collections
 import re
+import sys
 import urllib
 
 from .compat import urlparse
 from .six import text_type, string_types, u
+
+
+PY3 = sys.version_info[0] == 2
+PY2 = sys.version_info[0] == 3
 
 
 class QueryString(text_type):
@@ -145,7 +150,7 @@ def _qs_decode_py3(s):
     return urlparse.unquote_plus(s)
 
 
-if hasattr(urllib, 'quote'):
+if PY2:
     qs_encode = _qs_encode_py2
     qs_decode = _qs_decode_py2
     del _qs_encode_py3

--- a/urlobject/query_string.py
+++ b/urlobject/query_string.py
@@ -7,8 +7,8 @@ from .compat import urlparse
 from .six import text_type, string_types, u
 
 
-PY3 = sys.version_info[0] == 2
-PY2 = sys.version_info[0] == 3
+PY3 = sys.version_info[0] == 3
+PY2 = sys.version_info[0] == 2
 
 
 class QueryString(text_type):

--- a/urlobject/six.py
+++ b/urlobject/six.py
@@ -27,6 +27,8 @@ __author__ = "Benjamin Peterson <benjamin@python.org>"
 __version__ = "1.2.0"
 
 
+PY2 = sys.version_info[0] == 2
+
 # True if we are running on Python 3.
 PY3 = sys.version_info[0] == 3
 


### PR DESCRIPTION
Hi there, I found a conflict with the isort library in which urllib is patched: https://github.com/timothycrosley/isort/blob/develop/isort/pie_slice.py#L135
This causes urlobject to use `_qs_encode_py2` and `_qs_decode_py2` functions.

In Python3, this throws a `NameError: name 'unicode' is not defined` as Python3 no longer has the unicode type.

Found via a Django project using spurl which has urlobject as a dependency.