### PR TITLE
MANIFEST: include docs, tests & coveragerc in sdist

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,4 @@
+include .coveragerc
+include doc/*
+include test/*.py
 include UNLICENSE


### PR DESCRIPTION
Include doc, test subdirectories and .coveragerc file in MANIFEST.in so
that it is included when 'setup.py sdist' is used to generate
the archive for pypi (and it is not run in git checkout, apparently).