### PR TITLE
Add Power Support ppc64le

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,16 @@
 language: python
 
+arch:
+  - amd64
+  - ppc64le
+
 python:
-  - "2.6"
   - "2.7"
-  - "3.3"
   - "3.4"
   - "3.5"
   - "3.6"
+  - "3.7"
+  - "3.8"
 
 env:
   global:


### PR DESCRIPTION
Added power support for the travis.yml file with ppc64le. This is part of the Ubuntu distribution for ppc64le. This helps us simplify testing later when distributions are re-building and re-releasing. 