### PR TITLE
Use assertEqual instead of assertEquals for Python 3.11 compatibility.

### DIFF
--- a/test/urlobject_test.py
+++ b/test/urlobject_test.py
@@ -43,7 +43,7 @@ class SphinxDoctestsTest(unittest.TestCase):
         failed = result.failed
         attempted = result.attempted
         self.assertTrue(attempted > 0, "No doctests were found")
-        self.assertEquals(failed, 0, "There are failed doctests")
+        self.assertEqual(failed, 0, "There are failed doctests")
 
 
 class URLObjectRelativeTest(unittest.TestCase):


### PR DESCRIPTION
The deprecated aliases were removed in Python 3.11 in python/cpython#28268